### PR TITLE
Updated wording to clarify grid size of DEM

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -150,7 +150,7 @@
                 <span class="sr-only"></span>
               </div>
               Estimated Computation Time: ~1 min<br>
-              AZ is not definitive and is estimated using 30m DEM.
+              AZ is not definitive and is estimated using coarse DEM.
               <textarea id="wktStringTextArea" class="form-control" rows="4" @click="restoreDefaultColors()" v-model="info">
               </textarea>
               <br>


### PR DESCRIPTION
Updated the wording of "30m" grid size for the digital elevation model (DEM) to use the word "coarse". This should hopefully avoid confusion of the grid size wrt to the altitude threshold of 25m.